### PR TITLE
Fix validator_name regexp

### DIFF
--- a/lib/rspec/validator_spec_helper.rb
+++ b/lib/rspec/validator_spec_helper.rb
@@ -11,7 +11,7 @@ module RSpec
       base.instance_eval do
         let(:validator_name) do
           current_example = RSpec.try(:current_example) || RSpec.example
-          current_example.full_description.match(/\A\w+Validator/)[0]
+          current_example.full_description.match(/\A[\w:]+Validator/)[0]
         end
 
         let(:validator_class) { Object.const_get(validator_name) }

--- a/spec/rspec/validator_spec_helper_spec.rb
+++ b/spec/rspec/validator_spec_helper_spec.rb
@@ -108,4 +108,28 @@ RSpec.describe RSpec::ValidatorSpecHelper do
       it { expect(validator.options).to be_value(options[:gochiusa]) }
     end
   end
+
+  context 'when nested Validator' do
+    include RSpec::ValidatorSpecHelper
+    before(:all) do
+      TestNested = Class.new
+      TestNested.const_set :TestEachValidator, Class.new(ActiveModel::EachValidator)
+    end
+
+    before do
+      if RSpec.respond_to?(:current_example)
+        allow(RSpec).to(
+          receive_message_chain(:current_example, :full_description)
+              .and_return('TestNested::TestEachValidator')
+        )
+      else
+        RSpec.stub_chain(:example, :full_description)
+          .and_return('TestNested::TestEachValidator')
+      end
+    end
+
+    it { expect(validator_class).to eq TestNested::TestEachValidator }
+    it { expect(validator_name).to eq 'TestNested::TestEachValidator' }
+    it { expect(validation_name).to eq 'test_nested/test_each' }
+  end
 end


### PR DESCRIPTION
ネストしてると動作しなかったのでその対応です。

``` ruby
RSpec.describe Hoge::FugaValidator, type: :validator do
  describe '#validate_each' do
      context 'with invalid' do
        let(:value) { '1234-5678' }
        it { is_expected.to_not be_valid }
      end
  end
end
```

```
1) Hoge::FugaValidator#validate_each with invalid
     Failure/Error: it { is_expected.to_not be_valid }

     NoMethodError:
       undefined method `[]' for nil:NilClass
```
